### PR TITLE
Updates to apache module

### DIFF
--- a/src/scitoken.c
+++ b/src/scitoken.c
@@ -98,7 +98,7 @@ static const char *set_scitoken_param_exp(cmd_parms *cmd, void *config, const ch
 }
 
 static int enforcing_flag = 1;
-static char audience[255];
+static char audience[255] = "";
 
 static const char *set_scitoken_param_audience(cmd_parms *cmd, void *config, const char *aud)
 {
@@ -110,6 +110,8 @@ static const char *set_scitoken_param_enforcing(cmd_parms *cmd, void *config, co
 {
     if (flag[0] == 'f' || flag[0] == 'F' || flag[0] == 'n' || flag[0] == 'N'|| flag[0] == '0') {
         enforcing_flag = 0;
+    } else {
+        enforcing_flag = 1;
     }
     return NULL;
 }


### PR DESCRIPTION
Several changes rolled into one here:

1. Changed include path to be consistent with cpp-scitokens RPM in Linux epel repository.
2. Setting apache environment variables for SCITOKENS_SUB, SCITOKENS_ISS, etc. so you can for example pass them in headers to proxied applications, or use them in a CGI /Fastcgi script.
3. Added option to set the audience to something other than the hostname (i.e. for LCG Scitokens the audience is "https://wlcg.cern.ch/jwt/v1/any")
4. Added flag to turn of the "enforcer" call, so that an application can decide based on the environment variables whether to allow the calls.
I'm pretty sure if you don't use the audience and enforcing flags in the configuration, the behavior is unchanged.